### PR TITLE
Add `ErrorMapper` protocol for registering custom error mappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ![ErrorKit Logo](https://github.com/FlineDev/ErrorKit/blob/main/Logo.png?raw=true)
 
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FFlineDev%2FErrorKit%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/FlineDev/ErrorKit)
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FFlineDev%2FErrorKit%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/FlineDev/ErrorKit)
 
 # ErrorKit
@@ -69,7 +70,7 @@ do {
 }
 ```
 
-These enhanced descriptions are community-provided and fully localized mappings of common system errors to clearer, more actionable messages.
+These enhanced descriptions are community-provided and fully localized mappings of common system errors to clearer, more actionable messages. ErrorKit comes with built-in mappers for Foundation, CoreData, MapKit, and more. You can also create custom mappers for third-party libraries or your own error types.
 
 [Read more about Enhanced Error Descriptions →](https://swiftpackageindex.com/FlineDev/ErrorKit/documentation/errorkit/enhanced-error-descriptions)
 
@@ -179,7 +180,7 @@ Button("Report a Problem") {
 )
 ```
 
-With just a simple SwiftUI modifier, you can automatically include all log messages from Apple's unified logging system.
+With just a simple built-in SwiftUI modifier and the `logAttachment` helper function, you can easily include all log messages from Apple's unified logging system and let your users send them to you via email. Other integrations are also supported.
 
 [Read more about User Feedback and Logging →](https://swiftpackageindex.com/FlineDev/ErrorKit/documentation/errorkit/user-feedback-with-logs)
 
@@ -192,6 +193,8 @@ ErrorKit's features are designed to complement each other while remaining indepe
 2. **Add type safety with Swift 6 typed throws**, using the `Catching` protocol to solve nested error challenges. This pairs with error chain debugging to understand error flows through your app.
 
 3. **Save time with ready-made tools**: built-in error types for common scenarios and simple log collection for user feedback.
+
+4. **Extend with custom mappers**: Create error mappers for any library to improve error messages across your entire application.
 
 ## Adoption Path
 

--- a/Sources/ErrorKit/ErrorMapper.swift
+++ b/Sources/ErrorKit/ErrorMapper.swift
@@ -1,0 +1,101 @@
+/// A protocol for mapping domain-specific errors to user-friendly messages.
+///
+/// `ErrorMapper` allows users to extend ErrorKit's error mapping capabilities by providing custom mappings for errors from specific frameworks, libraries, or domains.
+///
+/// # Overview
+/// ErrorKit comes with built-in mappers for Foundation, CoreData, and MapKit errors.
+/// You can add your own mappers for other frameworks or custom error types using the ``ErrorKit/registerMapper(_:)`` function.
+/// ErrorKit will query all registered mappers in reverse order until one returns a non-nil result. This means, the last added mapper takes precedence.
+///
+/// # Example Implementation
+/// ```swift
+/// enum FirebaseErrorMapper: ErrorMapper {
+///     static func userFriendlyMessage(for error: Error) -> String? {
+///         switch error {
+///         case let authError as AuthErrorCode:
+///             switch authError.code {
+///             case .wrongPassword:
+///                 return String(localized: "The password is incorrect. Please try again.")
+///             case .userNotFound:
+///                 return String(localized: "No account found with this email address.")
+///             default:
+///                 return nil
+///             }
+///
+///         case let firestoreError as FirestoreErrorCode.Code:
+///             switch firestoreError {
+///             case .permissionDenied:
+///                 return String(localized: "You don't have permission to access this data.")
+///             case .unavailable:
+///                 return String(localized: "The service is temporarily unavailable. Please try again later.")
+///             default:
+///                 return nil
+///             }
+///
+///         case let storageError as StorageErrorCode:
+///             switch storageError {
+///             case .objectNotFound:
+///                 return String(localized: "The requested file could not be found.")
+///             case .quotaExceeded:
+///                 return String(localized: "Storage quota exceeded. Please try again later.")
+///             default:
+///                 return nil
+///             }
+///
+///         default:
+///             return nil
+///         }
+///     }
+/// }
+///
+/// // Register during app initialization
+/// ErrorKit.registerMapper(FirebaseErrorMapper.self)
+/// ```
+///
+/// Your mapper will be called automatically when using ``ErrorKit/userFriendlyMessage(for:)``:
+/// ```swift
+/// do {
+///     let user = try await Auth.auth().signIn(withEmail: email, password: password)
+/// } catch {
+///     let message = ErrorKit.userFriendlyMessage(for: error)
+///     // Message will be generated from FirebaseErrorMapper for Auth/Firestore/Storage errors
+/// }
+/// ```
+public protocol ErrorMapper {
+   /// Maps a given error to a user-friendly message if possible.
+   ///
+   /// This function is called by ErrorKit when attempting to generate a user-friendly error message.
+   /// It should check if the error is of a type it can handle and return an appropriate message, or return nil to allow other mappers to process the error.
+   ///
+   /// # Implementation Guidelines
+   /// - Return nil for errors your mapper doesn't handle
+   /// - Always use String(localized:) for message localization
+   /// - Keep messages clear, actionable, and non-technical
+   /// - Avoid revealing sensitive information
+   /// - Consider the user experience when crafting messages
+   ///
+   /// # Example
+   /// ```swift
+   /// static func userFriendlyMessage(for error: Error) -> String? {
+   ///     switch error {
+   ///     case let databaseError as DatabaseLibraryError:
+   ///         switch databaseError {
+   ///         case .connectionTimeout:
+   ///             return String(localized: "Database connection timed out. Please try again.")
+   ///         case .queryExecution:
+   ///             return String(localized: "Database query failed. Please contact support.")
+   ///         default:
+   ///             return nil
+   ///         }
+   ///     default:
+   ///         return nil
+   ///     }
+   /// }
+   /// ```
+   ///
+   /// - Note: Any error cases you don't provide a return value for will simply keep their original message. So only override the unclear ones or those that are not localized or you want other kinds of improvements for. No need to handle all possible cases just for the sake of it.
+   ///
+   /// - Parameter error: The error to potentially map to a user-friendly message
+   /// - Returns: A user-friendly message if this mapper can handle the error, or nil otherwise
+   static func userFriendlyMessage(for error: Error) -> String?
+}

--- a/Sources/ErrorKit/ErrorMappers/CoreDataErrorMapper.swift
+++ b/Sources/ErrorKit/ErrorMappers/CoreDataErrorMapper.swift
@@ -2,8 +2,8 @@
 import CoreData
 #endif
 
-extension ErrorKit {
-   static func userFriendlyCoreDataMessage(for error: Error) -> String? {
+enum CoreDataErrorMapper: ErrorMapper {
+   static func userFriendlyMessage(for error: Error) -> String? {
       #if canImport(CoreData)
       let nsError = error as NSError
 

--- a/Sources/ErrorKit/ErrorMappers/FoundationErrorMapper.swift
+++ b/Sources/ErrorKit/ErrorMappers/FoundationErrorMapper.swift
@@ -3,8 +3,8 @@ import Foundation
 import FoundationNetworking
 #endif
 
-extension ErrorKit {
-   static func userFriendlyFoundationMessage(for error: Error) -> String? {
+enum FoundationErrorMapper: ErrorMapper {
+   static func userFriendlyMessage(for error: Error) -> String? {
       switch error {
 
       // URLError: Networking errors

--- a/Sources/ErrorKit/ErrorMappers/MapKitErrorMapper.swift
+++ b/Sources/ErrorKit/ErrorMappers/MapKitErrorMapper.swift
@@ -2,8 +2,8 @@
 import MapKit
 #endif
 
-extension ErrorKit {
-   static func userFriendlyMapKitMessage(for error: Error) -> String? {
+enum MapKitErrorMapper: ErrorMapper {
+   static func userFriendlyMessage(for error: Error) -> String? {
       #if canImport(MapKit)
       if let mkError = error as? MKError {
          switch mkError.code {


### PR DESCRIPTION
Fixes #27.

## Proposed Changes

  - This adds a new `ErrorMapper` protocol, which also is now used by the custom mapping extensions.
  - A new function `ErrorKit.registerMapper(_:)` is used to register custom mappers, such as for 3rd-party libs.
  - The documentation was appropriately updated to mention custom error mapping capabilities.
