### PR TITLE
Support error chain description with opening indent level

### DIFF
--- a/Sources/ErrorKit/ErrorKit.swift
+++ b/Sources/ErrorKit/ErrorKit.swift
@@ -148,10 +148,12 @@ public enum ErrorKit {
    /// 2. Shows the underlying cause (DatabaseError.connectionFailed)
    /// 3. Provides the user-friendly message for context (users will report this)
    ///
-   /// - Parameter error: The error to describe, potentially containing nested errors
+   /// - Parameters:
+   ///    - error: The error to describe, potentially containing nested errors
+   ///    - indent: The initial indent string (normally "")
    /// - Returns: A formatted string showing the complete error hierarchy with indentation
-   public static func errorChainDescription(for error: Error) -> String {
-      return Self.chainDescription(for: error, indent: "", enclosingType: type(of: error))
+   public static func errorChainDescription(for error: Error, indent: String = "") -> String {
+      return Self.chainDescription(for: error, indent: indent, enclosingType: type(of: error))
    }
 
    private static func chainDescription(for error: Error, indent: String, enclosingType: Any.Type?) -> String {


### PR DESCRIPTION
## Proposed Changes

Sometimes I still want to wrap an error manually, and provide additional messaging on both the wrapper level and the leaf level.  the problem with simple `catch/caught` is only the bottom leaf level prints any details. here's a simplified example use case:

```
indirect enum SearchError: KittedError {
  case fetchFailure(request: URLRequest, networkError: NetworkError)
  case caught(Error)

  var userFriendlyMessage: String {
    switch self {
    case .fetchFailure(let request, let networkError):
      return
        """
        Failed to fetch url: \(request)
          \(ErrorKit.errorChainDescription(for: networkError, indent: "  "))
        """
    case .caught(let error):
      return ErrorKit.userFriendlyMessage(for: error)
    }
  }
}
```

by being able to pass my indent I can get this formatted nicely, an example end result printout when I print a `userFriendlyMessage` of a `.fetchFailure` is:

```
SearchError.fetchFailure(request: https://api.podcastindex.org/api/1.0/podcasts/trending?lang=en, networkError: ErrorKit.NetworkError.caught(Error Domain=NSURLErrorDomain Code=-1011 "(null)"))
└─ userFriendlyMessage: "Failed to fetch url: https://api.podcastindex.org/api/1.0/podcasts/trending?lang=en
  NetworkError
  └─ NSError [Class]
     └─ userFriendlyMessage: "A network error occurred: The operation couldn’t be completed. (NSURLErrorDomain error -1011.)""
```

id be more than happy to entertain alternative on how to achieve something like this.  this approach still only allows theoretical details to come out the top and the bottom of an error chain, everything in between would still be erased, but this is at least an improvement, and exposing the indent variable with a default of "" doesn't seem like its harming much.

a larger change would be to provide a way to print a more verbose error chain that does something like checking at every depth level to see if the Error is Throwable including the userFriendlyMessage when it exists, or to also include the `String(describing`  at every level.

