### PR TITLE
Add StringInterpolation helpers to render errors

### DIFF
--- a/Sources/ErrorKit/Helpers/String+ErrorKit.swift
+++ b/Sources/ErrorKit/Helpers/String+ErrorKit.swift
@@ -17,3 +17,13 @@ extension String {
    }
    #endif
 }
+
+extension String.StringInterpolation {
+   mutating public func appendInterpolation(error: some Error) {
+      appendInterpolation(ErrorKit.userFriendlyMessage(for: error))
+   }
+
+   mutating public func appendInterpolation(errorChain error: some Error) {
+      appendInterpolation(ErrorKit.errorChainDescription(for: error))
+   }
+}

--- a/Tests/ErrorKitTests/ErrorKitTests.swift
+++ b/Tests/ErrorKitTests/ErrorKitTests.swift
@@ -38,6 +38,27 @@ enum ErrorKitTests {
          let nestedError = DatabaseError.caught(FileError.caught(PermissionError.denied(permission: "~/Downloads/Profile.png")))
          #expect(ErrorKit.userFriendlyMessage(for: nestedError) == "Access to ~/Downloads/Profile.png was declined. To use this feature, please enable the permission in your device Settings.")
       }
+
+      @Test
+      static func errorStringInterpolation() async throws {
+         #expect("\(error: SomeThrowable())" == "Something failed hard.")
+      }
+
+      @Test
+      static func nestedErrorStringInterpolation() async throws {
+         let nestedError = DatabaseError.caught(FileError.caught(PermissionError.denied(permission: "~/Downloads/Profile.png")))
+         #expect("\(error: nestedError)" == "Access to ~/Downloads/Profile.png was declined. To use this feature, please enable the permission in your device Settings.")
+      }
+
+      @Test
+      static func chainedErrorStringInterpolation() async throws {
+         #expect(
+            "\(errorChain: SomeLocalizedError())" == """
+            SomeLocalizedError [Struct]
+            └─ userFriendlyMessage: "Something failed. It failed because it wanted to. Try again later."
+            """
+         )
+      }
    }
 
    enum ErrorChainDescription {


### PR DESCRIPTION
As discussed on Mastodon, this adds support for interpolating errors:

```swift
      @Test
      static func errorStringInterpolation() async throws {
         #expect("\(error: SomeThrowable())" == "Something failed hard.")
      }

      @Test
      static func nestedErrorStringInterpolation() async throws {
         let nestedError = DatabaseError.caught(FileError.caught(PermissionError.denied(permission: "~/Downloads/Profile.png")))
         #expect("\(error: nestedError)" == "Access to ~/Downloads/Profile.png was declined. To use this feature, please enable the permission in your device Settings.")
      }

      @Test
      static func chainedErrorStringInterpolation() async throws {
         #expect(
            "\(errorChain: SomeLocalizedError())" == """
            SomeLocalizedError [Struct]
            └─ userFriendlyMessage: "Something failed. It failed because it wanted to. Try again later."
            """
         )
      }
```

The argument label `error:` is required here or it'll break existing interpolation of `Swift.Error`. Alternatively (or additionally), there could be an overload

```swift
   mutating public func appendInterpolation(_ error: some Throwable) {
      appendInterpolation(ErrorKit.userFriendlyMessage(for: error))
   }
```

without the label but it's probably better to keep it symmetrical with `errorChain:`.