### PR TITLE
Downgrade to iOS and tvOS 15

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
    name: "ErrorKit",
    defaultLocalization: "en",
-   platforms: [.macOS(.v13), .iOS(.v16), .tvOS(.v16), .watchOS(.v9), .macCatalyst(.v16)],
+   platforms: [.macOS(.v13), .iOS(.v15), .tvOS(.v15), .watchOS(.v9), .macCatalyst(.v15)],
    products: [.library(name: "ErrorKit", targets: ["ErrorKit"])],
    dependencies: [
       // CryptoKit is not available on Linux, so we need Swift Crypto

--- a/Sources/ErrorKit/Logging/ErrorKit+OSLog.swift
+++ b/Sources/ErrorKit/Logging/ErrorKit+OSLog.swift
@@ -5,6 +5,7 @@
    import Foundation
    import OSLog
 
+   @available(iOS 16, tvOS 16, *)
    extension ErrorKit {
       /// Returns log data from the unified logging system for a specified time period and minimum level.
       ///
@@ -157,6 +158,7 @@
       }
    }
 
+   @available(iOS 16, tvOS 16, *)
    extension Duration {
       /// Returns the duration as a `TimeInterval`.
       ///


### PR DESCRIPTION
This PR uses availability in order to allow a downgrade of the minimum iOS & tvOS versions to 15.

I think this minor change could benefit the community since it only wraps the Duration API in one file.

## Proposed Changes

  - Add availability check for Duration API in ErrorKit+OSLog

All comments welcome